### PR TITLE
Allow `null` as result of `q.If` expression

### DIFF
--- a/src/types/query.d.ts
+++ b/src/types/query.d.ts
@@ -11,7 +11,7 @@ export module query {
   export function At(timestamp: ExprArg, expr: ExprArg): Expr;
   export function Let(vars: ExprArg, in_expr: ExprArg): Expr;
   export function Var(varName: ExprArg): Expr;
-  export function If(condition: ExprArg, then: ExprArg, _else: ExprArg): Expr;
+  export function If(condition: ExprArg, then: ExprArg | null, _else: ExprArg | null): Expr;
   export function Do(...args: ExprArg[]): Expr;
   export function Object(fields: ExprArg): Expr;
   export function Lambda(f: Lambda): Expr;


### PR DESCRIPTION
It has become useful to use 'null' as the result of a `q.If` expression.  The following is now possible:

```typescript
q.Let(
  {
    embeddedObject: q.Select(["data", "embeddedFieldName"], instance, null as any)
  },
  q.If(
    q.Equals([q.Var("embeddedObject"), null]),
    null,
    {
      /* q.Select stuff from the embeddedObject variable */
    }
  )
);
```